### PR TITLE
Update role for latest permissions

### DIFF
--- a/polaris-custom-role-definition.json
+++ b/polaris-custom-role-definition.json
@@ -50,7 +50,9 @@
           "Microsoft.Storage/storageAccounts/blobServices/containers/read",
           "Microsoft.Storage/storageAccounts/blobServices/containers/write",
           "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
-          "Microsoft.Compute/availabilitySets/read"
+          "Microsoft.Compute/availabilitySets/read",
+          "Microsoft.Storage/storageAccounts/read",
+          "Microsoft.Compute/diskEncryptionSets/read"
         ],
         "notActions": [],
         "dataActions": [


### PR DESCRIPTION
# Description

This pull request is to update the Azure custom role definition to the latest policy version: 1009. It hasn't been updated for policy version 1008 as well. Policies 1008 and 1009 add permissions necessary to support Indexing and SSE-CMK for disks, respectively.