### PR TITLE
Add private access permission groups

### DIFF
--- a/exocompute/version-1/permission-group-PRIVATE_ENDPOINTS.json
+++ b/exocompute/version-1/permission-group-PRIVATE_ENDPOINTS.json
@@ -1,0 +1,79 @@
+[
+  {
+    "Actions": [
+      {
+        "value": "Microsoft.Network/privateEndpoints/read",
+        "use_case": "Required to read private endpoints.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateEndpoints/write",
+        "use_case": "Required to create private endpoints.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateEndpoints/delete",
+        "use_case": "Required to delete private endpoints.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups/read",
+        "use_case": "Required to read private DNS Zone Groups.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups/write",
+        "use_case": "Required to create private DNS Zone Groups.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups/delete",
+        "use_case": "Required to delete private DNS Zone Groups.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateEndpoints/privateDnsZones/read",
+        "use_case": "Required to read private DNS Zones.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateEndpoints/privateDnsZones/write",
+        "use_case": "Required to create private DNS Zones.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateEndpoints/privateDnsZones/delete",
+        "use_case": "Required to delete private DNS Zones.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
+        "use_case": "Required to read virtual network links of private DNS Zones.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/write",
+        "use_case": "Required to create virtual network links for private DNS Zones.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/delete",
+        "use_case": "Required to delete virtual network links of private DNS Zones.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/join/action",
+        "use_case": "Required to link a private endpoint to a private DNS Zone.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/join/action",
+        "use_case": "Required to link a virtual network to a private DNS Zone.",
+        "scope": "subscription"
+      }
+    ],
+    "NotActions": null,
+    "DataActions": null,
+    "NotDataActions": null
+  }
+]

--- a/vm-protection/version-1/permission-group-SNAPSHOT_PRIVATE_ACCESS.json
+++ b/vm-protection/version-1/permission-group-SNAPSHOT_PRIVATE_ACCESS.json
@@ -1,0 +1,44 @@
+[
+  {
+    "Actions": [
+      {
+        "value": "Microsoft.Compute/diskAccesses/read",
+        "use_case": "Required to read disk access.",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/diskAccesses/write",
+        "use_case": "Required to create disk access.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/diskAccesses/delete",
+        "use_case": "Required to delete disk access.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/diskAccesses/privateEndpointConnections/read",
+        "use_case": "Required to read private endpoint connections of a disk access.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/diskAccesses/privateEndpointConnections/write",
+        "use_case": "Required to create private endpoint connections for a disk access.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/diskAccesses/privateEndpointConnections/delete",
+        "use_case": "Required to delete private endpoint connections from a disk access.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/diskAccesses/privateEndpointConnectionsApproval/action",
+        "use_case": "Required for auto-approval of private endpoint connection.",
+        "scope": "resourceGroup"
+      }
+    ],
+    "NotActions": null,
+    "DataActions": null,
+    "NotDataActions": null
+  }
+]


### PR DESCRIPTION
# Description

This diff adds permission groups in exocompute and vm-protection features for 
snapshot private access

Reference: [Doc](https://docs.google.com/document/d/1fsbRnq-keeuM1Fid1PBJXAqPDpIYF-1RtmQ9wa2PH2k/edit#heading=h.7v3mv9foxak5)

