### PR TITLE
Create v1.json for SQL_ARCHIVAL in cloud-native-archival-location feature

### DIFF
--- a/cloud-native-archival/permissions-group-SQL_ARCHIVAL/v1.json
+++ b/cloud-native-archival/permissions-group-SQL_ARCHIVAL/v1.json
@@ -3,17 +3,17 @@
 		"Actions": [
 			{
 				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/read",
-				"use_case": "Enabling AAD authentication to read Colossus metadata in Azure Sql Protection",
+				"use_case": "Creating, Reading and Writing Colossus metadata for Azure Sql Protection",
 				"scope": "resourceGroup"
 			},
 			{
 				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/write",
-				"use_case": "Enabling AAD authentication to write Colossus metadata in Azure Sql Protection",
+				"use_case": "Creating, Reading and Writing Colossus metadata for Azure Sql Protection",
 				"scope": "resourceGroup"
 			},
 			{
 				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/delete",
-				"use_case": "Enabling AAD authentication to delete Colossus metadata in Azure Sql Protection",
+				"use_case": "Creating, Reading and Writing Colossus metadata for Azure Sql Protection",
 				"scope": "resourceGroup"
 			}
 		],
@@ -21,27 +21,27 @@
 		"DataActions": [
 			{
 				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/entities/read",
-				"use_case": "Enabling AAD authentication to read Colossus metadata in Azure Sql Protection",
+				"use_case": "Creating, Reading and Writing Colossus metadata for Azure Sql Protection",
 				"scope": "resourceGroup"
 			},
 			{
 				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/entities/write",
-				"use_case": "Enabling AAD authentication to write Colossus metadata in Azure Sql Protection",
+				"use_case": "Creating, Reading and Writing Colossus metadata for Azure Sql Protection",
 				"scope": "resourceGroup"
 			},
 			{
 				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/entities/delete",
-				"use_case": "Enabling AAD authentication to read Colossus metadata in Azure Sql Protection",
+				"use_case": "Creating, Reading and Writing Colossus metadata for Azure Sql Protection",
 				"scope": "resourceGroup"
 			},
 			{
 				"value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/write",
-				"use_case": "Enabling AAD authentication to putBlockList in Blobs in Azure Sql Protection",
+				"use_case": "Storing and retrieving Blob data using tags for Azure Sql Protection",
 				"scope": "resourceGroup"
 			},
 			{
 				"value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/filter/action",
-				"use_case": "Enabling AAD authentication to putBlockList in Blobs in Azure Sql Protection",
+				"use_case": "Storing and retrieving Blob data using tags for Azure Sql Protection",
 				"scope": "resourceGroup"
 			}
 		],

--- a/cloud-native-archival/permissions-group-SQL_ARCHIVAL/v1.json
+++ b/cloud-native-archival/permissions-group-SQL_ARCHIVAL/v1.json
@@ -1,0 +1,50 @@
+[
+	{
+		"Actions": [
+			{
+				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/read",
+				"use_case": "Enabling AAD authentication to read Colossus metadata in Azure Sql Protection",
+				"scope": "resourceGroup"
+			},
+			{
+				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/write",
+				"use_case": "Enabling AAD authentication to write Colossus metadata in Azure Sql Protection",
+				"scope": "resourceGroup"
+			},
+			{
+				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/delete",
+				"use_case": "Enabling AAD authentication to delete Colossus metadata in Azure Sql Protection",
+				"scope": "resourceGroup"
+			}
+		],
+		"NotActions": null,
+		"DataActions": [
+			{
+				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/entities/read",
+				"use_case": "Enabling AAD authentication to read Colossus metadata in Azure Sql Protection",
+				"scope": "resourceGroup"
+			},
+			{
+				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/entities/write",
+				"use_case": "Enabling AAD authentication to write Colossus metadata in Azure Sql Protection",
+				"scope": "resourceGroup"
+			},
+			{
+				"value": "Microsoft.Storage/storageAccounts/tableServices/tables/entities/delete",
+				"use_case": "Enabling AAD authentication to read Colossus metadata in Azure Sql Protection",
+				"scope": "resourceGroup"
+			},
+			{
+				"value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/write",
+				"use_case": "Enabling AAD authentication to putBlockList in Blobs in Azure Sql Protection",
+				"scope": "resourceGroup"
+			},
+			{
+				"value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/filter/action",
+				"use_case": "Enabling AAD authentication to putBlockList in Blobs in Azure Sql Protection",
+				"scope": "resourceGroup"
+			}
+		],
+		"NotDataActions": null
+	}
+]


### PR DESCRIPTION
# Description
Adds Permissions for Azure archival location needed for Azure Sql Protection in a new permission subgroup names SQL_ARCHIVAL.
[Doc](https://docs.google.com/document/d/1adkrqDB02O2yxwD_VytfsRntyLFeghxfM_G2PfL528g/edit#heading=h.cotgntszporw)


## Related Issue

_[link to the issue here](https://rubrik.atlassian.net/browse/SPARK-385959)_

## Motivation and Context

This change adds permissions to access Azure Blob store and Tables in StorageAccounts for Azure SQL protection.
