### PR TITLE
Add availability set and marketplace offering cloud account permissions

### DIFF
--- a/servers-and-apps/permissions-group-CLOUD_CLUSTER/v1.json
+++ b/servers-and-apps/permissions-group-CLOUD_CLUSTER/v1.json
@@ -1,0 +1,186 @@
+[
+  {
+    "Actions": [
+      {
+        "value": "Microsoft.Compute/disks/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/disks/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/locations/vmSizes/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/skus/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/instanceView/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/start/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/ipconfigurations/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/join/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/join/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/checkResourceName/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/locations/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resourceGroups/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resourceGroups/resources/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resourceGroups/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resources/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/extensions/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Authorization/locks/*",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/listkeys/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.ManagedIdentity/userAssignedIdentities/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.ManagedIdentity/userAssignedIdentities/assign/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/images/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/availabilitySets/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/availabilitySets/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/availabilitySets/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.MarketplaceOrdering/offerTypes/publishers/offers/plans/agreements/read",
+        "scope": "subscription"
+      }
+    ],
+    "NotActions": null,
+    "DataActions": [
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
+        "scope": "subscription"
+      }
+    ],
+    "NotDataActions": null
+  }
+]

--- a/servers-and-apps/version-1/permissions-group-CLOUD_CLUSTER.json
+++ b/servers-and-apps/version-1/permissions-group-CLOUD_CLUSTER.json
@@ -1,0 +1,186 @@
+[
+  {
+    "Actions": [
+      {
+        "value": "Microsoft.Compute/disks/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/disks/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/locations/vmSizes/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/skus/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/instanceView/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/start/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/ipconfigurations/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/join/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/join/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/checkResourceName/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/locations/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resourceGroups/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resourceGroups/resources/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resourceGroups/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resources/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/extensions/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Authorization/locks/*",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/listkeys/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.ManagedIdentity/userAssignedIdentities/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.ManagedIdentity/userAssignedIdentities/assign/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/images/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/availabilitySets/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/availabilitySets/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/availabilitySets/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.MarketplaceOrdering/offerTypes/publishers/offers/plans/agreements/read",
+        "scope": "subscription"
+      }
+    ],
+    "NotActions": null,
+    "DataActions": [
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
+        "scope": "subscription"
+      }
+    ],
+    "NotDataActions": null
+  }
+]


### PR DESCRIPTION
# Description
Add Azure availability set (read, write and delete) and
marketplace offering read cloud account permissions.

## Related Issue
[SPARK-407599](https://rubrik.atlassian.net/secure/QuickSearch.jspa?searchString=SPARK-407599)

## Motivation and Context
Adds new permissions for Availability Sets and marketplace 
offerings for Brik Awareness and CCProvision wizard revamp work
