### PR TITLE
Update Export-Restore basic permission to v3

### DIFF
--- a/vm-protection/permissions-group-EXPORT_AND_RESTORE/v3.json
+++ b/vm-protection/permissions-group-EXPORT_AND_RESTORE/v3.json
@@ -1,0 +1,61 @@
+[
+    {
+      "Actions": [
+        {
+          "value": "Microsoft.Compute/disks/write",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.Compute/disks/delete",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.Compute/virtualMachines/delete",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.Compute/virtualMachines/powerOff/action",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.Compute/virtualMachines/write",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.Network/networkInterfaces/delete",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.Network/networkInterfaces/write",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.KeyVault/vaults/deploy/action",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.Compute/virtualMachines/extensions/write",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.Network/networkSecurityGroups/write",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.Network/networkSecurityGroups/delete",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.Compute/virtualMachines/start/action",
+          "scope": "subscription"
+        },
+        {
+          "value": "Microsoft.KeyVault/vaults/read",
+          "scope": "subscription"
+        }
+      ],
+      "NotActions": null,
+      "DataActions": null,
+      "NotDataActions": null
+    }
+  ]


### PR DESCRIPTION
# Description

New permissions are added to export and restore group to list key vaults for cross-region ADE export.

Verified that `permissions-parity-test` UT passes.
```
=== RUN   TestPermissionParity
=== RUN   TestPermissionParity/VM_Protection_permissions
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/vm-protection/permissions-group-SNAPSHOT_PRIVATE_ACCESS/v1.json
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/vm-protection/permissions-group-BASIC/v5.json
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/vm-protection/permissions-group-EXPORT_AND_RESTORE/v3.json
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/vm-protection/permissions-group-FILE_LEVEL_RECOVERY/v1.json
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/vm-protection/permissions-group-CLOUD_CLUSTER_ES/v1.json
=== RUN   TestPermissionParity/SQL_DB_Protection_permissions
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/sql-db-protection/permissions-group-BASIC/v2.json
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/sql-db-protection/permissions-group-RECOVERY/v1.json
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/sql-db-protection/permissions-group-BACKUP_V2/v1.json
=== RUN   TestPermissionParity/SQL_MI_Protection_permissions
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/sql-mi-protection/permissions-group-RECOVERY/v1.json
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/sql-mi-protection/permissions-group-BACKUP_V2/v1.json
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/sql-mi-protection/permissions-group-BASIC/v1.json
=== RUN   TestPermissionParity/Blob_Protection_permissions
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/blob-protection/permissions-group-BASIC/v2.json
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/blob-protection/permissions-group-RECOVERY/v3.json
=== RUN   TestPermissionParity/Exocompute_permissions
2025/01/22 06:55:30 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/exocompute/permissions-group-PRIVATE_ENDPOINTS/v2.json
2025/01/22 06:55:31 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/exocompute/permissions-group-CUSTOMER_MANAGED_BASIC/v2.json
2025/01/22 06:55:31 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/exocompute/permissions-group-BASIC/v4.json
=== RUN   TestPermissionParity/Cloud_Native_Archival_permissions
2025/01/22 06:55:31 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/cloud-native-archival/permissions-group-BASIC/v2.json
2025/01/22 06:55:31 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/cloud-native-archival/permissions-group-ENCRYPTION/v1.json
2025/01/22 06:55:31 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/cloud-native-archival/permissions-group-SQL_ARCHIVAL/v1.json
=== RUN   TestPermissionParity/Cloud_Native_Archival_Encryption_permissions
2025/01/22 06:55:31 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/cloud-native-archival-encryption/permissions-group-BASIC/v1.json
2025/01/22 06:55:31 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/patch-1/cloud-native-archival-encryption/permissions-group-ENCRYPTION/v1.json
--- PASS: TestPermissionParity (1.12s)
    --- PASS: TestPermissionParity/VM_Protection_permissions (0.23s)
    --- PASS: TestPermissionParity/SQL_DB_Protection_permissions (0.16s)
    --- PASS: TestPermissionParity/SQL_MI_Protection_permissions (0.15s)
    --- PASS: TestPermissionParity/Blob_Protection_permissions (0.13s)
    --- PASS: TestPermissionParity/Exocompute_permissions (0.17s)
    --- PASS: TestPermissionParity/Cloud_Native_Archival_permissions (0.16s)
    --- PASS: TestPermissionParity/Cloud_Native_Archival_Encryption_permissions (0.13s)
PASS
```
## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

Why is this change required? What problem does it solve?
