### PR TITLE
Create new permission group in exocompute for CUSTOMER_HOSTED_LOGGING

### DIFF
--- a/exocompute/permissions-group-CUSTOMER_HOSTED_LOGGING/v1.json
+++ b/exocompute/permissions-group-CUSTOMER_HOSTED_LOGGING/v1.json
@@ -1,0 +1,95 @@
+[
+  {
+    "Actions": [
+      {
+        "value": "Microsoft.Storage/storageAccounts/read",
+        "use_case": "Returns the list of storage accounts or gets the properties for the specified storage account.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/write",
+        "use_case": "Creates a storage account with the specified parameters or update the properties or tags or adds custom domain for the specified storage account.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/delete",
+        "use_case": "Deletes an existing storage account.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/listkeys/action",
+        "use_case": "Returns the access keys for the specified storage account.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/listAccountSas/action",
+        "use_case": "Returns the Account SAS token for the specified storage account.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+        "use_case": "Return a container or a list of containers in storage account.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/write",
+        "use_case": "Write to a container in storage account.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
+        "use_case": "Delete a container from storage account.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/generateUserDelegationKey/action",
+        "use_case": "Generate a user delegation key for blob storage account.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/managementPolicies/read",
+        "use_case": "Read management policies from storage accounts.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/managementPolicies/write",
+        "use_case": "Write management policies for storage accounts.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/managementPolicies/delete",
+        "use_case": "Delete management policies for storage accounts.",
+        "scope": "resourceGroup"
+      }
+    ],
+    "NotActions": null,
+    "DataActions": [
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
+        "use_case": "Return a blob or a list of blobs.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write",
+        "use_case": "Write to a blob.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete",
+        "use_case": "Delete a blob.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/move/action",
+        "use_case": "Move a blob within the same storage account.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/add/action",
+        "use_case": "Create or upload new blobs in a container.",
+        "scope": "resourceGroup"
+      }
+    ],
+    "NotDataActions": null
+  }
+]


### PR DESCRIPTION
Ran the Permission parity test locally 

```
RUN   TestPermissionParity/Exocompute_permissions
2025/02/03 05:42:38 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/add-customer-hosted-logging-perms/exocompute/permissions-group-CUSTOMER_HOSTED_LOGGING/v1.json
2025/02/03 05:42:38 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/add-customer-hosted-logging-perms/exocompute/permissions-group-BASIC/v5.json
2025/02/03 05:42:39 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/add-customer-hosted-logging-perms/exocompute/permissions-group-PRIVATE_ENDPOINTS/v2.json
2025/02/03 05:42:39 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/add-customer-hosted-logging-perms/exocompute/permissions-group-CUSTOMER_MANAGED_BASIC/v2.json

--- PASS: TestPermissionParity (1.44s)
    --- PASS: TestPermissionParity/VM_Protection_permissions (0.22s)
    --- PASS: TestPermissionParity/SQL_DB_Protection_permissions (0.17s)
    --- PASS: TestPermissionParity/SQL_MI_Protection_permissions (0.16s)
    --- PASS: TestPermissionParity/Blob_Protection_permissions (0.13s)
    --- PASS: TestPermissionParity/Exocompute_permissions (0.47s)
    --- PASS: TestPermissionParity/Cloud_Native_Archival_permissions (0.16s)
    --- PASS: TestPermissionParity/Cloud_Native_Archival_Encryption_permissions (0.13s)
PASS
Target //rubrik/cloudaccounts/service/feature/azure/permissions/parity-test:go_default_test up-to-date:
  bazel-bin/rubrik/cloudaccounts/service/feature/azure/permissions/parity-test/go_default_test_/go_default_test
INFO: Elapsed time: 7.165s, Critical Path: 3.47s
INFO: 2 processes: 1 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
//rubrik/cloudaccounts/service/feature/azure/permissions/parity-test:go_default_test PASSED in 1.8s

```