### PR TITLE
Fix permissions in customer_hosted_logging v1

### DIFF
--- a/exocompute/permissions-group-CUSTOMER_HOSTED_LOGGING/v1.json
+++ b/exocompute/permissions-group-CUSTOMER_HOSTED_LOGGING/v1.json
@@ -12,11 +12,6 @@
         "scope": "resourceGroup"
       },
       {
-        "value": "Microsoft.Storage/storageAccounts/delete",
-        "use_case": "Deletes an existing storage account.",
-        "scope": "resourceGroup"
-      },
-      {
         "value": "Microsoft.Storage/storageAccounts/listkeys/action",
         "use_case": "Returns the access keys for the specified storage account.",
         "scope": "resourceGroup"
@@ -24,6 +19,11 @@
       {
         "value": "Microsoft.Storage/storageAccounts/listAccountSas/action",
         "use_case": "Returns the Account SAS token for the specified storage account.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/listServiceSas/action",
+        "use_case": "Returns the Service SAS token for the specified storage account.",
         "scope": "resourceGroup"
       },
       {


### PR DESCRIPTION
Tested permissions-parity-test locally

```
=== RUN   TestPermissionParity/Exocompute_permissions
2025/02/05 09:21:02 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/fix_missing_customer_hosted_logging/exocompute/permissions-group-CUSTOMER_MANAGED_BASIC/v2.json
2025/02/05 09:21:02 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/fix_missing_customer_hosted_logging/exocompute/permissions-group-CUSTOMER_HOSTED_LOGGING/v1.json
2025/02/05 09:21:02 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/fix_missing_customer_hosted_logging/exocompute/permissions-group-BASIC/v5.json
2025/02/05 09:21:02 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/fix_missing_customer_hosted_logging/exocompute/permissions-group-PRIVATE_ENDPOINTS/v2.json
=== RUN   TestPermissionParity/Cloud_Native_Archival_permissions
2025/02/05 09:21:02 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/fix_missing_customer_hosted_logging/cloud-native-archival/permissions-group-BASIC/v2.json
2025/02/05 09:21:03 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/fix_missing_customer_hosted_logging/cloud-native-archival/permissions-group-ENCRYPTION/v1.json
2025/02/05 09:21:03 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/fix_missing_customer_hosted_logging/cloud-native-archival/permissions-group-SQL_ARCHIVAL/v1.json
=== RUN   TestPermissionParity/Cloud_Native_Archival_Encryption_permissions
2025/02/05 09:21:03 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/fix_missing_customer_hosted_logging/cloud-native-archival-encryption/permissions-group-BASIC/v1.json
2025/02/05 09:21:03 [DEBUG] GET https://raw.githubusercontent.com/adish-13/azure-roledefinition-cloud-native-protection-for-azure/refs/heads/fix_missing_customer_hosted_logging/cloud-native-archival-encryption/permissions-group-ENCRYPTION/v1.json
--- PASS: TestPermissionParity (6.00s)
    --- PASS: TestPermissionParity/VM_Protection_permissions (1.55s)
    --- PASS: TestPermissionParity/SQL_DB_Protection_permissions (1.10s)
    --- PASS: TestPermissionParity/SQL_MI_Protection_permissions (0.95s)
    --- PASS: TestPermissionParity/Blob_Protection_permissions (0.70s)
    --- PASS: TestPermissionParity/Exocompute_permissions (0.12s)
    --- PASS: TestPermissionParity/Cloud_Native_Archival_permissions (0.96s)
    --- PASS: TestPermissionParity/Cloud_Native_Archival_Encryption_permissions (0.62s)
PASS
Target //rubrik/cloudaccounts/service/feature/azure/permissions/parity-test:go_default_test up-to-date:
  bazel-bin/rubrik/cloudaccounts/service/feature/azure/permissions/parity-test/go_default_test_/go_default_test
INFO: Elapsed time: 13.309s, Critical Path: 7.79s
INFO: 2 processes: 1 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
//rubrik/cloudaccounts/service/feature/azure/permissions/parity-test:go_default_test PASSED in 6.3s
```