### PR TITLE
Add permissions for automated_networking_setup permission group

### DIFF
--- a/exocompute/permissions-group-AUTOMATED_NETWORKING_SETUP/v3.json
+++ b/exocompute/permissions-group-AUTOMATED_NETWORKING_SETUP/v3.json
@@ -1,0 +1,100 @@
+[
+  {
+    "Actions": [
+      {
+        "value": "Microsoft.Network/virtualNetworks/write",
+        "scope": "resourceGroup",
+        "use_case": "Creates or updates a virtual network."
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/read",
+        "scope": "resourceGroup",
+        "use_case": "Returns the properties of a virtual network or lists virtual networks."
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/delete",
+        "scope": "resourceGroup",
+        "use_case": "Deletes a virtual network."
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/write",
+        "scope": "resourceGroup",
+        "use_case": "Creates or updates a network security group."
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/read",
+        "scope": "resourceGroup",
+        "use_case": "Returns the properties of a network security group or lists network security groups."
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/delete",
+        "scope": "resourceGroup",
+        "use_case": "Deletes a network security group."
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/write",
+        "scope": "resourceGroup",
+        "use_case": "Creates or updates a subnet within a virtual network."
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/read",
+        "scope": "resourceGroup",
+        "use_case": "Returns the properties of a subnet or lists subnets within a virtual network."
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/delete",
+        "scope": "resourceGroup",
+        "use_case": "Deletes a subnet from a virtual network."
+      },
+      {
+
+	"value":   "Microsoft.Resources/deployments/read",
+	"scope":   "resourceGroup",
+	"use_case": "Reads a deployment."
+      },
+      {
+	"value":   "Microsoft.Resources/deployments/write",
+	"scope":   "resourceGroup",
+	"use_case": "Creates a deployment or updates an existing deployment."
+      },
+      {
+	"value":   "Microsoft.Resources/deployments/delete",
+	"scope":   "resourceGroup",
+	"use_case": "Deletes a deployment."
+      },
+      {
+	"value":   "Microsoft.Resources/deployments/operationstatuses/read",
+	"scope":   "resourceGroup",
+	"use_case": "Reads the status of a deployment operation."
+      },
+      {
+	"value":   "Microsoft.Network/networkSecurityGroups/join/action",
+	"scope":   "resourceGroup",
+	"use_case": "Join network security groups."
+      },
+      {
+        "value":   "Microsoft.Network/virtualNetworks/subnets/join/action",
+	"scope":   "resourceGroup",
+	"use_case": "Join virtual network subnets."
+      },
+      {
+        "value":   "Microsoft.Network/networkSecurityGroups/securityRules/read",
+	"scope":   "resourceGroup",
+	"use_case": "Read network security group security rules."
+      },
+      {
+        "value":   "Microsoft.Network/networkSecurityGroups/securityRules/write",
+	"scope":   "resourceGroup",
+	"use_case": "Write network security group security rules."
+      },
+      {
+        "value":   "Microsoft.Network/networkSecurityGroups/securityRules/delete",
+	"scope":   "resourceGroup",
+	"use_case": "Delete network security group security rules."
+      }
+    ],
+    "NotActions": null,
+    "DataActions": null,
+    "NotDataActions": null
+  }
+]


### PR DESCRIPTION
This PR adds new permissions in the permission group 
Automated_networking_setup, the new permissions are 
required to manage network security group and its
rules.
