### PR TITLE
Add version5 for export and restore PG

### DIFF
--- a/vm-protection/permissions-group-BASIC/v6.json
+++ b/vm-protection/permissions-group-BASIC/v6.json
@@ -1,0 +1,206 @@
+[
+  {
+    "Actions": [
+      {
+        "value": "Microsoft.Compute/disks/read",
+        "use_case": "Use to retrieve the properties of a disk.",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/locations/vmSizes/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/skus/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/instanceView/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/ipconfigurations/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/checkResourceName/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/locations/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resourceGroups/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resourceGroups/resources/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resources/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/availabilitySets/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/diskEncryptionSets/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/galleries/images/versions/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/disks/beginGetAccess/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/disks/endGetAccess/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/join/action",
+        "scope": "subscription"
+      },
+      {
+        "value":   "Microsoft.Compute/diskAccesses/read",
+        "scope":   "subscription",
+        "use_case": "Required for linking a disk access resource to a managed disk snapshot."
+      },
+      {
+        "value": "Microsoft.Compute/snapshots/read",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/snapshots/write",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/snapshots/delete",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/snapshots/beginGetAccess/action",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/snapshots/endGetAccess/action",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Resources/subscriptions/resourceGroups/write",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Authorization/locks/write",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Authorization/locks/delete",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/listServiceSas/action",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/disks/write",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/disks/delete",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/delete",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/write",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.KeyVault/vaults/deploy/action",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/extensions/write",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/write",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/write",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/extensions/read",
+        "scope": "subscription",
+        "use_case": "Required for the backup and recovery of ADE enabled VM."
+      },
+      {
+        "value": "Microsoft.Authorization/locks/read",
+        "scope": "subscription",
+        "use_case": "Required to check subscription level locks during backup."
+      }
+    ],
+    "NotActions": null,
+    "DataActions": [
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete",
+        "scope": "resourceGroup"
+      }
+    ],
+    "NotDataActions": null
+  }
+]

--- a/vm-protection/permissions-group-EXPORT_AND_RESTORE/v4.json
+++ b/vm-protection/permissions-group-EXPORT_AND_RESTORE/v4.json
@@ -1,0 +1,49 @@
+[
+  {
+    "Actions": [
+      {
+        "value": "Microsoft.Compute/disks/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/disks/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.KeyVault/vaults/deploy/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/extensions/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/start/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.KeyVault/vaults/read",
+        "scope": "subscription"
+      }
+    ],
+    "NotActions": null,
+    "DataActions": null,
+    "NotDataActions": null
+  }
+]

--- a/vm-protection/permissions-group-EXPORT_AND_RESTORE/v5.json
+++ b/vm-protection/permissions-group-EXPORT_AND_RESTORE/v5.json
@@ -1,0 +1,53 @@
+[
+  {
+    "Actions": [
+      {
+        "value": "Microsoft.Compute/disks/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/disks/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/delete",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkInterfaces/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.KeyVault/vaults/deploy/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/extensions/write",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Compute/virtualMachines/start/action",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.KeyVault/vaults/read",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/join/action",
+        "scope": "subscription"
+      }
+    ],
+    "NotActions": null,
+    "DataActions": null,
+    "NotDataActions": null
+  }
+]


### PR DESCRIPTION
# Description

This PR adds v5 for export and restore to remove power off permissions and 
version 6 for basic permission. 

```
=== RUN   TestPermissionParity
=== RUN   TestPermissionParity/VM_Protection_permissions
2025/09/01 22:18:21 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/vm-protection/permissions-group-CUSTOMER_MANAGED_STORAGE_INDEXING/v1.json
2025/09/01 22:18:21 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/vm-protection/permissions-group-EXPORT_AND_RESTORE_POWER_OFF_VM/v1.json
2025/09/01 22:18:21 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/vm-protection/permissions-group-BASIC/v6.json
2025/09/01 22:18:21 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/vm-protection/permissions-group-EXPORT_AND_RESTORE/v5.json
2025/09/01 22:18:22 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/vm-protection/permissions-group-FILE_LEVEL_RECOVERY/v1.json
2025/09/01 22:18:22 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/vm-protection/permissions-group-CLOUD_CLUSTER_ES/v1.json
2025/09/01 22:18:22 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/vm-protection/permissions-group-SNAPSHOT_PRIVATE_ACCESS/v1.json
--- PASS: TestPermissionParity/VM_Protection_permissions (1.22s)
=== RUN   TestPermissionParity/SQL_DB_Protection_permissions
2025/09/01 22:18:22 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/sql-db-protection/permissions-group-BASIC/v2.json
2025/09/01 22:18:22 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/sql-db-protection/permissions-group-RECOVERY/v1.json
2025/09/01 22:18:23 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/sql-db-protection/permissions-group-BACKUP_V2/v1.json
--- PASS: TestPermissionParity/SQL_DB_Protection_permissions (1.24s)
=== RUN   TestPermissionParity/SQL_MI_Protection_permissions
2025/09/01 22:18:23 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/sql-mi-protection/permissions-group-BASIC/v1.json
2025/09/01 22:18:24 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/sql-mi-protection/permissions-group-RECOVERY/v1.json
2025/09/01 22:18:24 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/sql-mi-protection/permissions-group-BACKUP_V2/v1.json
--- PASS: TestPermissionParity/SQL_MI_Protection_permissions (1.31s)
=== RUN   TestPermissionParity/Blob_Protection_permissions
2025/09/01 22:18:24 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/blob-protection/permissions-group-BASIC/v2.json
2025/09/01 22:18:25 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/blob-protection/permissions-group-RECOVERY/v3.json
--- PASS: TestPermissionParity/Blob_Protection_permissions (0.86s)
=== RUN   TestPermissionParity/Exocompute_permissions
2025/09/01 22:18:25 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/exocompute/permissions-group-AKS_CUSTOM_PRIVATE_DNS_ZONE/v1.json
2025/09/01 22:18:26 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/exocompute/permissions-group-BASIC/v6.json
2025/09/01 22:18:26 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/exocompute/permissions-group-PRIVATE_ENDPOINTS/v4.json
2025/09/01 22:18:26 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/exocompute/permissions-group-CUSTOMER_MANAGED_BASIC/v2.json
2025/09/01 22:18:27 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/exocompute/permissions-group-CUSTOMER_HOSTED_LOGGING/v1.json
2025/09/01 22:18:27 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/exocompute/permissions-group-AUTOMATED_NETWORKING_SETUP/v3.json
2025/09/01 22:18:27 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/exocompute/permissions-group-SERVICE_ENDPOINT_AUTOMATION/v1.json
--- PASS: TestPermissionParity/Exocompute_permissions (2.44s)
=== RUN   TestPermissionParity/Cloud_Native_Archival_permissions
2025/09/01 22:18:28 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/cloud-native-archival/permissions-group-SQL_ARCHIVAL/v1.json
2025/09/01 22:18:28 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/cloud-native-archival/permissions-group-BASIC/v2.json
2025/09/01 22:18:29 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/cloud-native-archival/permissions-group-ENCRYPTION/v1.json
--- PASS: TestPermissionParity/Cloud_Native_Archival_permissions (1.18s)
=== RUN   TestPermissionParity/Cloud_Native_Archival_Encryption_permissions
2025/09/01 22:18:29 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/cloud-native-archival-encryption/permissions-group-BASIC/v1.json
2025/09/01 22:18:29 [DEBUG] GET https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/export-4/cloud-native-archival-encryption/permissions-group-ENCRYPTION/v1.json
--- PASS: TestPermissionParity/Cloud_Native_Archival_Encryption_permissions (0.87s)
--- PASS: TestPermissionParity (9.13s)
PASS
```

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

_Please link to the issue here_

## Motivation and Context

Why is this change required? What problem does it solve?
