### PR TITLE
Revert "Add Postgres Flex Server BASIC v2 (merges former BACKUP_V2)"

### DIFF
--- a/postgres-flexible-server-protection/permissions-group-BACKUP_V2/v1.json
+++ b/postgres-flexible-server-protection/permissions-group-BACKUP_V2/v1.json
@@ -2,21 +2,6 @@
   {
     "Actions": [
       {
-        "value": "Microsoft.Resources/subscriptions/resourceGroups/read",
-        "use_case": "Getting or listing resource groups.",
-        "scope": "subscription"
-      },
-      {
-        "value": "Microsoft.DBforPostgreSQL/flexibleServers/read",
-        "use_case": "Retrieving the list of flexible servers or retrieving the properties for the specified flexible server.",
-        "scope": "subscription"
-      },
-      {
-        "value": "Microsoft.DBforPostgreSQL/checkNameAvailability/action",
-        "use_case": "Checking if a flexible server name is available before provisioning.",
-        "scope": "subscription"
-      },
-      {
         "value": "Microsoft.DBforPostgreSQL/flexibleServers/write",
         "use_case": "Provisioning a temporary flexible server via point-in-time restore in the Rubrik-managed resource group.",
         "scope": "resourceGroup"


### PR DESCRIPTION
Reverts rubrikinc/azure-roledefinition-cloud-native-protection-for-azure#61

## Summary

  Reverts PR #61 ("Add Postgres Flex Server BASIC v2 (merges former BACKUP_V2)").

  ## Why revert

  The consolidation in #61 removed `postgres-flexible-server-protection/permissions-group-BACKUP_V2/v1.json` (folding it into `BASIC/v2.json`). This broke the downstream permissions-parity test in `scaledata/sdmain` on the
  `fedramp-v2.6.5` release branch, which still pins to `permissions-group-BACKUP_V2/v1.json`:

  permission_parity_test.go:184: False assertion failed:
      Reason: expected "false", got "true" instead
      Error while fetching raw file from github url
      'https://raw.githubusercontent.com/rubrikinc/azure-roledefinition-cloud-native-protection-for-azure/master/postgres-flexible-server-protection/permissions-group-BACKUP_V2/v1.json'
      Status code: '404'

  This fails every `fedramp-v2.6.5` build, blocking the release. Reverting restores the prior layout so the release pipeline is unblocked. The BASIC v2 / BACKUP_V2 consolidation can be re-landed once the sdmain side
  (`polaris/src/rubrik/cloudaccounts/service/feature/azure/permissions/...`) is updated on both `master` and the relevant release branches to consume the new structure.

  ## Verification

  Pointed sdmain's parity-test helper at this revert branch and re-ran the test against the `fedramp-v2.6.5` worktree:

  //rubrik/cloudaccounts/service/feature/azure/permissions/parity-test:go_default_test PASSED in 11.6s
  Executed 1 out of 1 test: 1 test passes.

  All 8 subtests pass — VM, SQL DB, SQL MI, Blob, Exocompute, Cloud Native Archival, Cloud Native Archival Encryption, and **Postgres Flexible Server Protection**.