### PR TITLE
Add ANS v5 (privateDnsZones + virtualNetworkLinks) for exocompute

### DIFF
--- a/exocompute/permissions-group-AUTOMATED_NETWORKING_SETUP/v5.json
+++ b/exocompute/permissions-group-AUTOMATED_NETWORKING_SETUP/v5.json
@@ -1,0 +1,94 @@
+[
+  {
+    "Actions": [
+      {
+        "value": "Microsoft.Network/virtualNetworks/write",
+        "use_case": "Creates or updates a virtual network.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/read",
+        "use_case": "Returns the properties of a virtual network or lists virtual networks.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/write",
+        "use_case": "Creates or updates a network security group.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/read",
+        "use_case": "Returns the properties of a network security group or lists network security groups.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/write",
+        "use_case": "Creates or updates a subnet within a virtual network.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/read",
+        "use_case": "Returns the properties of a subnet or lists subnets within a virtual network.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Resources/deployments/read",
+        "use_case": "Reads a deployment.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Resources/deployments/write",
+        "use_case": "Creates a deployment or updates an existing deployment.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Resources/deployments/operationstatuses/read",
+        "use_case": "Reads the status of a deployment operation.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/join/action",
+        "use_case": "Join network security groups.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "use_case": "Join virtual network subnets.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/securityRules/read",
+        "use_case": "Read network security group security rules.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/networkSecurityGroups/securityRules/write",
+        "use_case": "Write network security group security rules.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/read",
+        "use_case": "Returns the properties of a private DNS zone or lists private DNS zones.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/write",
+        "use_case": "Creates or updates a private DNS zone.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
+        "use_case": "Returns the properties of a virtual network link or lists virtual network links.",
+        "scope": "resourceGroup"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/write",
+        "use_case": "Creates or updates a virtual network link within a private DNS zone.",
+        "scope": "resourceGroup"
+      }
+    ],
+    "NotActions": null,
+    "DataActions": null,
+    "NotDataActions": null
+  }
+]


### PR DESCRIPTION
## Summary

Adds **version 5** of the exocompute `AUTOMATED_NETWORKING_SETUP` permission
group (`exocompute/permissions-group-AUTOMATED_NETWORKING_SETUP/v5.json`).

v5 is the full v4 action set **plus** four new actions, all at `resourceGroup`
scope (least-privilege — the zone and link live in the exocompute resource
group):

| Action | Why it is needed |
| --- | --- |
| `Microsoft.Network/privateDnsZones/read` | Get/list the per-region `*.postgres.database.azure.com` private DNS zone (get-or-create) |
| `Microsoft.Network/privateDnsZones/write` | Create the private DNS zone |
| `Microsoft.Network/privateDnsZones/virtualNetworkLinks/read` | Check the VNet link from the exocompute VNet to the zone (get-or-create) |
| `Microsoft.Network/privateDnsZones/virtualNetworkLinks/write` | Create the VNet link |

These permissions let the exocompute app registration provision the private DNS
zone and VNet link required for VNet-injected **Postgres Flexible Server**
backups.

v5 is a strict superset of v4: 13 inherited actions + 4 new = 17 total. No v4
actions were removed or modified.

## Context

This is the external-facing mirror of the internal grant-surface change in
scaledata/sdmain#228362, which registers ANS Version5 behind the Azure Postgres
Flexible Server release flag. Publishing v5 here lets customers re-grant the new
permissions ahead of enforcement.

## Test Plan

- `v5.json` is valid JSON.
- Verified v5 is a strict superset of v4 (all 13 v4 actions present, plus exactly
  the 4 new private DNS zone / virtual network link actions).
- All actions use `resourceGroup` scope and carry a `use_case` annotation,
  consistent with v4.
