### PR TITLE
Add PG Flex recovery v2 permission group

### DIFF
--- a/postgres-flexible-server-protection/permissions-group-RECOVERY/v2.json
+++ b/postgres-flexible-server-protection/permissions-group-RECOVERY/v2.json
@@ -1,0 +1,75 @@
+[
+  {
+    "Actions": [
+      {
+        "value": "Microsoft.DBforPostgreSQL/flexibleServers/write",
+        "use_case": "Provisioning the recovery flexible server (PITR create-new / LTR create-new) and PATCHing the SKU on bring-your-own-server.",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/read",
+        "use_case": "Listing virtual networks in the recovery wizard network configuration step.",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/read",
+        "use_case": "Listing subnets in the recovery wizard network configuration step.",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "use_case": "Delegating the recovery flexible server NIC into the customer-selected subnet (Azure requirement for VNet integration).",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/virtualNetworks/join/action",
+        "use_case": "Linking the customer's virtual network to the private DNS zone (Azure linked-scope check on virtualNetworkLinks/write; without this the LinkedAuthorizationFailed error fires before the server is provisioned).",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/read",
+        "use_case": "Validating the customer-supplied private DNS zone before provisioning.",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/join/action",
+        "use_case": "Attaching the recovery flexible server to the customer-selected private DNS zone (Azure requirement for VNet integration).",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
+        "use_case": "Idempotency check for the VNet-to-DNS-zone link before recreating it during recovery.",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/write",
+        "use_case": "Creating the virtualNetworkLink that binds the recovery flexible server's VNet to the customer's private DNS zone (Azure auto-creates this link on first flex server provisioning into a zone).",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.KeyVault/vaults/read",
+        "use_case": "Listing key vaults in the recovery wizard encryption configuration step.",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.ManagedIdentity/userAssignedIdentities/read",
+        "use_case": "Listing user-assigned managed identities for customer-managed key encryption during recovery.",
+        "scope": "subscription"
+      },
+      {
+        "value": "Microsoft.ManagedIdentity/userAssignedIdentities/assign/action",
+        "use_case": "Assigning the customer-selected user-assigned managed identity to the recovery flexible server.",
+        "scope": "subscription"
+      }
+    ],
+    "NotActions": null,
+    "DataActions": [
+      {
+        "value": "Microsoft.KeyVault/vaults/keys/read",
+        "use_case": "Listing customer-managed keys in the recovery wizard encryption configuration step (Key Vault data plane action; required when the vault uses Azure RBAC authorization).",
+        "scope": "subscription"
+      }
+    ],
+    "NotDataActions": null
+  }
+]

--- a/postgres-flexible-server-protection/permissions-group-RECOVERY/v2.json
+++ b/postgres-flexible-server-protection/permissions-group-RECOVERY/v2.json
@@ -37,11 +37,6 @@
         "scope": "subscription"
       },
       {
-        "value": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
-        "use_case": "Idempotency check for the VNet-to-DNS-zone link before recreating it during recovery.",
-        "scope": "subscription"
-      },
-      {
         "value": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/write",
         "use_case": "Creating the virtualNetworkLink that binds the recovery flexible server's VNet to the customer's private DNS zone (Azure auto-creates this link on first flex server provisioning into a zone).",
         "scope": "subscription"

--- a/postgres-flexible-server-protection/permissions-group-RECOVERY/v2.json
+++ b/postgres-flexible-server-protection/permissions-group-RECOVERY/v2.json
@@ -37,6 +37,11 @@
         "scope": "subscription"
       },
       {
+        "value": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read",
+        "use_case": "Reading the VNet-to-DNS-zone link during recovery; Azure performs a read-check on the link before deciding to create or update it on the flex-server PUT. Validated against a real PUT against an empty DNS zone: removing this action fires AuthorizationFailed on Microsoft.Network/privateDnsZones/virtualNetworkLinks/read before the link is touched.",
+        "scope": "subscription"
+      },
+      {
         "value": "Microsoft.Network/privateDnsZones/virtualNetworkLinks/write",
         "use_case": "Creating the virtualNetworkLink that binds the recovery flexible server's VNet to the customer's private DNS zone (Azure auto-creates this link on first flex server provisioning into a zone).",
         "scope": "subscription"


### PR DESCRIPTION
## Summary

Adds the v2 RECOVERY permission set for the `postgres-flexible-server-protection` feature group at `postgres-flexible-server-protection/permissions-group-RECOVERY/v2.json`.

Mirrors the spec landing in `scaledata/sdmain` at:

```
polaris/src/rubrik/cloudaccounts/service/feature/azure/permissions/postgres-flexible-server-protection/recovery/2.go
```

sdmain PR: https://github.com/scaledata/sdmain/pull/233484

The permission parity test in sdmain (`polaris/src/rubrik/cloudaccounts/service/feature/azure/permissions/parity-test/permissions_parity_test.go`) fetches the JSON from this repo via `raw.githubusercontent.com`. Without `v2.json` here, that test will 404 once the sdmain PR bumps `GetLatestPostgresFlexServerProtectionRecoveryPermissions` to return `Version2`.

## What this group covers

v2 supports the **PITR + create-new-server** and **LTR + bring-your-own-server** recovery wizard flows:

- **VNet integration (private access)** — `virtualNetworks/{read,subnets/read,subnets/join/action,join/action}` and `privateDnsZones/{read,join/action,virtualNetworkLinks/read,virtualNetworkLinks/write}`
- **Customer-managed-key encryption** — `KeyVault/vaults/read`, `KeyVault/vaults/keys/read` (DataAction — required when the vault uses Azure RBAC authorization), `ManagedIdentity/userAssignedIdentities/{read,assign/action}`
- **Recovery flexible server PUT** — `DBforPostgreSQL/flexibleServers/write` (carried forward from v1)

All actions at subscription scope because the customer can select resources from any RG within their subscription.

## Validation

Tested by provisioning an Azure Postgres Flexible Server with VNet integration against a Service Principal granted only this role (no Reader, no Owner, no inherited permissions):

- `az postgres flexible-server create` with `--subnet` + `--private-dns-zone` against a delegated subnet in `RubrikBackups-do-not-delete` and the `privatelink.postgres.database.azure.com` zone returned HTTP 200 with the expected server resource.
- The first attempt surfaced three real gaps in the initial spec — `virtualNetworks/join/action`, `privateDnsZones/virtualNetworkLinks/write`, and `KeyVault/vaults/keys/read` being in the Action slot instead of the DataAction slot for vaults with `enableRbacAuthorization=true`. All three are addressed in this v2.
- Test server, role assignment, and custom role were cleaned up after validation.

Each of the 13 permission strings (12 Actions + 1 DataAction) is present in the live Azure operation catalog (verified via `az provider operation show` for `Microsoft.DBforPostgreSQL`, `Microsoft.Network`, `Microsoft.KeyVault`, `Microsoft.ManagedIdentity`).
